### PR TITLE
Dave/snapshot in gcp

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ podTemplate(label: label, containers: [
                   sh 'mvn integration-test'
                 }
                 stage('Deploy snapshot') {
-                    withCredentials([[$class: 'FileBinding', credentialsId: 'monplat-jenkins-json', variable: 'GOOGLE_APPLICATION_CREDENTIALS']]) {
+                    withCredentials([file(credentialsId: 'monplat-jenkins-json', variable: 'GOOGLE_APPLICATION_CREDENTIALS')])
                         mvn deploy
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,11 +18,9 @@ podTemplate(label: label, containers: [
                   sh 'mvn integration-test'
                 }
                 stage('Deploy snapshot') {
-                  environment {
-                      GOOGLE_APPLICATION_FILE = credentials('monplat-jenkins-7f0eaa46ecdc.json')
-                  }
-                  sh 'export GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_FILE'
-                  sh 'mvn deploy'
+                    withCredentials([[$class: 'StringBinding', credentialsId: 'monplat-jenkins-json', variable: 'GOOGLE_APPLICATION_CREDENTIALS']]) {
+                        mvn deploy
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ podTemplate(label: label, containers: [
                   sh 'mvn integration-test'
                 }
                 stage('Deploy snapshot') {
-                    withCredentials([[$class: 'StringBinding', credentialsId: 'monplat-jenkins-json', variable: 'GOOGLE_APPLICATION_CREDENTIALS']]) {
+                    withCredentials([[$class: 'FileBinding', credentialsId: 'monplat-jenkins-json', variable: 'GOOGLE_APPLICATION_CREDENTIALS']]) {
                         mvn deploy
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,22 +6,22 @@ podTemplate(label: label, containers: [
 {
     node(label) {
         container('maven') {
-            environment {
-                GOOGLE_APPLICATION_FILE = credentials('monplat-jenkins-json')
-            }
             stage('Checkout') {
                 checkout scm
             }
             ansiColor('xterm') {
                 // TODO Add persistentVolumeClaim to greatly speed this up
                 stage('Maven install') {
-                  sh 'export GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_FILE'
                   sh 'mvn install -Dmaven.test.skip=true'
                 }
                 stage('Integration Test') {
                   sh 'mvn integration-test'
                 }
                 stage('Deploy snapshot') {
+                  environment {
+                      GOOGLE_APPLICATION_FILE = credentials('monplat-jenkins-json')
+                  }
+                  sh 'export GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_FILE'
                   sh 'mvn deploy'
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,9 @@ podTemplate(label: label, containers: [
   containerTemplate(name: 'maven', image: 'maven:3-jdk-8', ttyEnabled: true, command: 'cat')
   ])
 {
+    environment {
+        GOOGLE_APPLICATION_CREDENTIALS = credentials('monplat-jenkins')
+    }
     node(label) {
         container('maven') {
             stage('Checkout') {
@@ -16,6 +19,9 @@ podTemplate(label: label, containers: [
                 }
                 stage('Integration Test') {
                   sh 'mvn integration-test'
+                }
+                stage('Deploy snapshot') {
+                  sh 'mvn archetype:generate -DgroupId=com.test.apps -DartifactId=GoogleWagonTest -DarchetypeArtifactId=maven-archetype-quickstart -DinteractiveMode=false'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ podTemplate(label: label, containers: [
                 }
                 stage('Deploy snapshot') {
                     withCredentials([file(credentialsId: 'monplat-jenkins-json', variable: 'GOOGLE_APPLICATION_CREDENTIALS')]) {
-                        mvn deploy
+                        sh 'mvn deploy'
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ podTemplate(label: label, containers: [
   ])
 {
     environment {
-        GOOGLE_APPLICATION_CREDENTIALS = credentials('monplat-jenkins-json')
+        GOOGLE_APPLICATION_FILE = credentials('monplat-jenkins-json')
     }
     node(label) {
         container('maven') {
@@ -15,6 +15,7 @@ podTemplate(label: label, containers: [
             ansiColor('xterm') {
                 // TODO Add persistentVolumeClaim to greatly speed this up
                 stage('Maven install') {
+                  sh 'export GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_FILE'
                   sh 'mvn install -Dmaven.test.skip=true'
                 }
                 stage('Integration Test') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ podTemplate(label: label, containers: [
   ])
 {
     environment {
-        GOOGLE_APPLICATION_CREDENTIALS = credentials('monplat-jenkins')
+        GOOGLE_APPLICATION_CREDENTIALS = credentials('monplat-jenkins-json')
     }
     node(label) {
         container('maven') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ podTemplate(label: label, containers: [
                   sh 'mvn integration-test'
                 }
                 stage('Deploy snapshot') {
-                    withCredentials([file(credentialsId: 'monplat-jenkins-json', variable: 'GOOGLE_APPLICATION_CREDENTIALS')])
+                    withCredentials([file(credentialsId: 'monplat-jenkins-json', variable: 'GOOGLE_APPLICATION_CREDENTIALS')]) {
                         mvn deploy
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ podTemplate(label: label, containers: [
                   sh 'mvn integration-test'
                 }
                 stage('Deploy snapshot') {
-                  sh 'mvn archetype:generate -DgroupId=com.test.apps -DartifactId=GoogleWagonTest -DarchetypeArtifactId=maven-archetype-quickstart -DinteractiveMode=false'
+                  sh 'mvn deploy'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,11 +4,11 @@ podTemplate(label: label, containers: [
   containerTemplate(name: 'maven', image: 'maven:3-jdk-8', ttyEnabled: true, command: 'cat')
   ])
 {
-    environment {
-        GOOGLE_APPLICATION_FILE = credentials('monplat-jenkins-json')
-    }
     node(label) {
         container('maven') {
+            environment {
+                GOOGLE_APPLICATION_FILE = credentials('monplat-jenkins-json')
+            }
             stage('Checkout') {
                 checkout scm
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ podTemplate(label: label, containers: [
                 }
                 stage('Deploy snapshot') {
                   environment {
-                      GOOGLE_APPLICATION_FILE = credentials('monplat-jenkins-json')
+                      GOOGLE_APPLICATION_FILE = credentials('monplat-jenkins-7f0eaa46ecdc.json')
                   }
                   sh 'export GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_FILE'
                   sh 'mvn deploy'

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
   <distributionManagement>
     <snapshotRepository>
         <id>salus-snapshot-bucket</id>
-        <url>gs://artifacts.monplat-jenkins.appspot.com/snapshot</url>
+        <url>gs://monplat-jenkins-artifacts/snapshot</url>
     </snapshotRepository>
     <repository>
       <id>bintray-racker-maven</id>

--- a/pom.xml
+++ b/pom.xml
@@ -119,10 +119,20 @@
 
       </plugins>
     </pluginManagement>
-
+    <extensions>
+        <extension>
+            <groupId>com.gkatzioura.maven.cloud</groupId>
+            <artifactId>google-storage-wagon</artifactId>
+            <version>1.2</version>
+        </extension>
+    </extensions>
   </build>
 
   <distributionManagement>
+    <snapshotRepository>
+        <id>salus-snapshot-bucket</id>
+        <url>gs://artifacts.monplat-jenkins.appspot.com/snapshot</url>
+    </snapshotRepository>
     <repository>
       <id>bintray-racker-maven</id>
       <name>racker-maven</name>


### PR DESCRIPTION
# Resolves
This allows for SNAPSHOTs to be deployed/stored in Google Cloud Storage.

# How
Followed the instructions with the plugin.
https://github.com/gkatzioura/CloudStorageMaven/tree/master/GoogleStorageWagon

## How to test
Verified with 
```bash
gsutil ls -r "gs://monplat-jenkins-artifacts/snapshot/**"                                                                                                              gs://monplat-jenkins-artifacts/snapshot/
gs://monplat-jenkins-artifacts/snapshot/com/rackspace/salus/salus-app-base/0.1.0-SNAPSHOT/maven-metadata.xml
gs://monplat-jenkins-artifacts/snapshot/com/rackspace/salus/salus-app-base/0.1.0-SNAPSHOT/maven-metadata.xml.md5
gs://monplat-jenkins-artifacts/snapshot/com/rackspace/salus/salus-app-base/0.1.0-SNAPSHOT/maven-metadata.xml.sha1
gs://monplat-jenkins-artifacts/snapshot/com/rackspace/salus/salus-app-base/0.1.0-SNAPSHOT/salus-app-base-0.1.0-20181127.023433-1.pom
gs://monplat-jenkins-artifacts/snapshot/com/rackspace/salus/salus-app-base/0.1.0-SNAPSHOT/salus-app-base-0.1.0-20181127.023433-1.pom.md5
gs://monplat-jenkins-artifacts/snapshot/com/rackspace/salus/salus-app-base/0.1.0-SNAPSHOT/salus-app-base-0.1.0-20181127.023433-1.pom.sha1
gs://monplat-jenkins-artifacts/snapshot/com/rackspace/salus/salus-app-base/maven-metadata.xml
gs://monplat-jenkins-artifacts/snapshot/com/rackspace/salus/salus-app-base/maven-metadata.xml.md5
gs://monplat-jenkins-artifacts/snapshot/com/rackspace/salus/salus-app-base/maven-metadata.xml.sha1
```

# Why
A centralized repository that is "close" to where the tests and builds will be done.

## Note
Squash the many, many test commits.