### PR TITLE
dave/cloud_build: Properly deploying

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,11 @@
+steps:
+  - name: 'gcr.io/cloud-builders/gsutil'
+    id: GET_SETTINGS
+    args: ['cp', 'gs://salus-mavenrepository/m2-settings.xml', '.mvn/settings.xml']
+  - name: 'gcr.io/cloud-builders/mvn'
+    id: INTEGRATION TEST
+    args: ['integration-test', '-s', '.mvn/settings.xml']
+  - name: 'gcr.io/cloud-builders/mvn'
+    id: DEPLOY
+    args: ['deploy', '-s', '.mvn/settings.xml']
+


### PR DESCRIPTION
# Resolves
Moves away from Jenkins and uses Google Cloud Build to run tests and deploy.
