### PR TITLE
Simplify the base configuration of jib for the app image builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,28 +43,19 @@ plugin specification:
 
 This app base module preconfigures the [jib maven plugin](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin);
 however, each application needs to "activate" the plugin to enable Docker image building by 
-specifying the following. 
-
-> **NOTE** as you can see, the convention is to place the plugin within
-a `docker` profile block. This will ensure a "default" maven build will avoid the Docker
-build behavior and keep things simple. The profile can be activated by adding `-P docker` to
-the maven command-line.
+adding the following to the build>plugins section along with the `spring-boot-maven-plugin` 
+mentioned above. 
 
 ```xml
-<profiles>
-    <profile>
-        <id>docker</id>
-
-        <build>
-            <plugins>
-                <plugin>
-                    <groupId>com.google.cloud.tools</groupId>
-                    <artifactId>jib-maven-plugin</artifactId>
-                </plugin>
-            </plugins>
-        </build>
-    </profile>
-</profiles>
+<build>
+    <plugins>
+        <!-- spring-boot-maven-plugin plugin would be here too-->
+        <plugin>
+            <groupId>com.google.cloud.tools</groupId>
+            <artifactId>jib-maven-plugin</artifactId>
+        </plugin>
+    </plugins>
+</build>
 ```
 
 By default, the jib plugin is configured to use an OpenJDK JRE Alpine base image; however, the
@@ -107,8 +98,11 @@ More information about the configuration of [the run goal can be found here](htt
 
 ## Building local Docker images
 
-When the Maven profile "docker" is activated, the application module will produce
-a Docker image as part of the `package` goal.
+Along with the usual Maven goals add `jib:dockerBuild` to also include a Docker image build, such as
+
+```bash
+mvn package jib:dockerBuild
+```
 
 > **NOTE** this specific goal requires access to a Docker daemon, such as via Docker for Desktop
 or a mounted Docker socket.
@@ -130,19 +124,5 @@ In the application module, run the following replacing `$PROJECT_ID` with the Go
 Cloud project's ID, which is of the form of an identifer and number separated by a dash:
 
 ```
-mvn -P docker -Ddocker.image.prefix=gcr.io/myapp-12345 deploy
+mvn -Ddocker.image.prefix=gcr.io/myapp-12345 jib:dockerBuild
 ```
-
-If you would like to avoid pushing the Maven artifact during this build, then add
-
-```
--Dmaven.deploy.skip=true
-```
-
-If the local system doesn't have Docker installed, you can still perform the remote publish and
-skip the local Docker build by adding:
-
-```
--DskipLocalDockerBuild=true
-```
-

--- a/pom.xml
+++ b/pom.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~    Copyright 2018 Rackspace US, Inc.
+  ~ Copyright 2019 Rackspace US, Inc.
   ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  ~
-  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
@@ -38,8 +36,13 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
+
+    <!-- Specifies the prefix of the Docker image to tag.
+         In CI will be set with the registry designator to override this "local" prefix of "racker" -->
     <docker.image.prefix>racker</docker.image.prefix>
-    <skipLocalDockerBuild>false</skipLocalDockerBuild>
+    <!-- Specifies the image tag to apply in addition to the tag derived from the
+         application pom's project version  field -->
+    <docker.image.latest>latest</docker.image.latest>
   </properties>
 
   <repositories>
@@ -80,41 +83,10 @@
           <groupId>com.google.cloud.tools</groupId>
           <artifactId>jib-maven-plugin</artifactId>
           <version>0.9.13</version>
-          <executions>
-            <execution>
-              <id>build-local</id>
-              <phase>package</phase>
-              <goals>
-                <goal>dockerBuild</goal>
-              </goals>
-              <configuration>
-                <to>
-                  <image>${project.artifactId}</image>
-                  <tags>
-                    <tag>${project.version}</tag>
-                    <tag>latest</tag>
-                  </tags>
-                </to>
-                <skip>${skipLocalDockerBuild}</skip>
-              </configuration>
-            </execution>
-            <execution>
-              <id>tag-specific</id>
-              <phase>deploy</phase>
-              <goals>
-                <goal>build</goal>
-              </goals>
-              <configuration>
-                <to>
-                  <image>${docker.image.prefix}/${project.artifactId}</image>
-                  <tags>
-                    <tag>${project.version}</tag>
-                  </tags>
-                </to>
-              </configuration>
-            </execution>
-          </executions>
           <configuration>
+            <!-- The configuration located in there becomes the default for each application's
+                 image build; however, each is free to override any of this configuration such
+                 as when an alternate base image is needed. -->
             <from>
               <image>openjdk:8u181-jre-alpine</image>
             </from>
@@ -123,6 +95,13 @@
                 <port>8080</port>
               </ports>
             </container>
+            <to>
+              <image>${docker.image.prefix}/${project.artifactId}</image>
+              <tags>
+                <tag>${project.version}</tag>
+                <tag>${docker.image.latest}</tag>
+              </tags>
+            </to>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
# Resolves

The base part of SALUS-167

# What

Rather than embed the jib usage as executions, just configure it such that goals like `jib:dockerBuild` can be distinctly referenced from the CI builds.

# How

Merges the config down into the plugin's top level config rather than dispersing amongst the executions. It also blends the "latest" tag handling into the top level config by introducing another Maven property. That property could be later used to create per-branch tags that move as changes are committed and the image built for the respective branch.

## How to test

Perform a Maven install at the bundle level.

# TODO

There will be follow up PRs for each application's pom to shift the plugin out of the profile section.