### PR TITLE
Pre-declare dependency for actuator metrics via Stackdriver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,15 +45,23 @@
     <docker.image.latest>latest</docker.image.latest>
   </properties>
 
-  <repositories>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>jcenter</id>
-      <url>https://jcenter.bintray.com</url>
-    </repository>
-  </repositories>
+  <dependencyManagement>
+    <!-- These dependencies will be pre-versioned but still need to be declared (without version)
+     by child application poms. -->
+    <dependencies>
+
+      <dependency>
+        <!-- Spring Boot doesn't yet bundle support for actuator metrics via Stackdriver, so this
+         autoconfig module fills that gap for now.
+         Refer to https://github.com/itzg/stackdriver-spring-boot-autoconfigure for info about
+          how to configure this -->
+        <groupId>com.github.itzg</groupId>
+        <artifactId>stackdriver-spring-boot-autoconfigure</artifactId>
+        <version>1.1.0</version>
+      </dependency>
+
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <pluginManagement>
@@ -108,12 +116,37 @@
     </pluginManagement>
   </build>
 
-<distributionManagement>
-    <snapshotRepository>
-        <id>snapshots</id>
-        <name>artifactory-artifactory-0-snapshots</name>
-        <url>https://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-snapshot-local</url>
-    </snapshotRepository>
-</distributionManagement>
+  <distributionManagement>
+      <snapshotRepository>
+          <id>snapshots</id>
+          <name>artifactory-artifactory-0-snapshots</name>
+          <url>https://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-snapshot-local</url>
+      </snapshotRepository>
+  </distributionManagement>
+
+  <repositories>
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>jcenter</id>
+      <url>https://jcenter.bintray.com</url>
+    </repository>
+    <repository>
+      <id>salus-dev-snapshots</id>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <url>http://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-snapshot</url>
+    </repository>
+    <repository>
+      <id>salus-dev-release</id>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <url>http://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-release</url>
+    </repository>
+  </repositories>
+
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,10 @@
       </snapshots>
       <url>http://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-release</url>
     </repository>
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </repository>
   </repositories>
 
 


### PR DESCRIPTION
# Resolves

Thought of this during https://jira.rax.io/browse/CMC-2218

# What

Declares a version of the Stackdriver autoconfig module we can use for exporting app metrics.

# TODO

After this PR we can update each of the apps to include the dependency, but disable the stackdriver export by default. With that, the kube deploys can be configured with the proper GCP project ID and enable the exporter.