### PR TITLE
Added latest and git short sha as docker tags to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
               <image>${docker.image.prefix}/${project.artifactId}</image>
               <tags>
                 <tag>${project.version}</tag>
-                <tag>latest</tag>
+                <tag>${docker.image.latest}</tag>
                 <tag>${env.SHORT_SHA}</tag>
               </tags>
             </to>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,8 @@
               <image>${docker.image.prefix}/${project.artifactId}</image>
               <tags>
                 <tag>${project.version}</tag>
-                <tag>${docker.image.latest}</tag>
+                <tag>latest</tag>
+                <tag>${env.SHORT_SHA}</tag>
               </tags>
             </to>
           </configuration>


### PR DESCRIPTION
# Resolves
This allows for project Docker containers to be properly tagged during cloud builds.

# What
Docker containers will now be tagged with ":latest", the project version (ie. :0.0.1-SNAPSHOT), and the short sha for git (ie. `git rev-parse --short HEAD`).

# To Do
This was inspired by @itzg 's comment on racker/salus-telemetry-auth-service/pull/6 
