### PR TITLE
Corrected artifactory repos in pom.xml

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -3,6 +3,6 @@ steps:
     id: GET_SETTINGS
     args: ['cp', 'gs://salus-mavenrepository/m2-settings.xml', '.mvn/settings.xml']
   - name: 'gcr.io/cloud-builders/mvn'
-    id: VERIFY
-    args: ['verify', '-s', '.mvn/settings.xml']
+    id: DEPLOY
+    args: ['deploy', '-s', '.mvn/settings.xml']
 

--- a/pom.xml
+++ b/pom.xml
@@ -118,11 +118,14 @@
   </build>
 
   <distributionManagement>
-      <snapshotRepository>
-          <id>snapshots</id>
-          <name>artifactory-artifactory-0-snapshots</name>
-          <url>https://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-snapshot-local</url>
-      </snapshotRepository>
+    <snapshotRepository>
+      <id>salus-dev-snapshots</id>
+      <url>https://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-snapshot-local</url>
+    </snapshotRepository>
+    <repository>
+      <id>salus-dev-release</id>
+      <url>https://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-release-local</url>
+    </repository>
   </distributionManagement>
 
   <repositories>
@@ -130,28 +133,28 @@
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
-      <id>jcenter</id>
-      <url>https://jcenter.bintray.com</url>
-    </repository>
-    <repository>
-      <id>salus-dev-snapshots</id>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <url>http://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-snapshot</url>
-    </repository>
-    <repository>
       <id>salus-dev-release</id>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
       <url>http://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-release</url>
     </repository>
     <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
+      <snapshots />
+      <id>salus-dev-snapshots</id>
+      <url>http://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-snapshot</url>
     </repository>
   </repositories>
-
+  <pluginRepositories>
+    <pluginRepository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>salus-dev-release</id>
+      <url>http://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-release</url>
+    </pluginRepository>
+    <pluginRepository>
+      <snapshots />
+      <id>salus-dev-snapshots</id>
+      <url>http://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-snapshot</url>
+    </pluginRepository>
+  </pluginRepositories>
 
 </project>


### PR DESCRIPTION
# Resolves
SALUS-333

# What
This ensures that the Artifactory repos are correct in the pom.xml. Also, added cloudbuild-deploy.yaml that will deploy the needful and cloudbuild.yaml will only do a `mvn verify`.

# TODO
Updated Google Cloud Build to ensure non-master/tag commits only run cloudbuild.yaml and that all tags and master branch commits run cloudbuild-deploy.yaml.
[GCB Triggers](https://console.cloud.google.com/cloud-build/triggers?organizationId=767495606862&project=salus-220516)