### PR TITLE
Upgrade to Spring Boot 2.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.6.RELEASE</version>
+    <version>2.1.8.RELEASE</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-601

# What

Upgrade to Spring Boot 2.1.8. Nothing major, but does include a few dependency updates relevant to us:
- https://github.com/spring-projects/spring-boot/releases/tag/v2.1.7.RELEASE
- https://github.com/spring-projects/spring-boot/releases/tag/v2.1.8.RELEASE