### PR TITLE
Declare maven-artifact version for apps to use

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
         <artifactId>guava</artifactId>
         <version>27.0.1-jre</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-artifact</artifactId>
+        <version>3.6.3</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-724

# What

The java-semver library is too strict with its version parsing, since it only handles compliant semantic versions.

# How

Switch over to the version parsing included in [maven's artifact library](https://maven.apache.org/ref/3.3.3/maven-artifact/apidocs/org/apache/maven/artifact/versioning/package-frame.html) ...only the managed dependency version needs to be declared here.