### PR TITLE
Added jib creationTime setting to avoid default of EPOCH

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
           <!-- plugin docs located at https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin -->
           <groupId>com.google.cloud.tools</groupId>
           <artifactId>jib-maven-plugin</artifactId>
-          <version>0.9.13</version>
+          <version>2.0.0</version>
           <configuration>
             <!-- The configuration located in there becomes the default for each application's
                  image build; however, each is free to override any of this configuration such
@@ -134,6 +134,8 @@
               <image>openjdk:11.0.3-slim</image>
             </from>
             <container>
+              <!-- Avoid using the default, EPOCH, since that complicates pruning of images in the registry -->
+              <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
               <ports>
                 <port>8080</port>
               </ports>


### PR DESCRIPTION
# Resolves

Helps https://jira.rax.io/browse/CMO-676

# What

When listing images in GCR it shows the timestamp as `1969-12-31T18:00:00`.

# How

Apparently that [is indeed the default behavior](https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#why-is-my-image-created-48-years-ago). Since I didn't find any advice out there about strategies to set the `creationTime` semi-automatically (like based on a git commit time) I decided just to use their `USE_CURRENT_TIMESTAMP` value. It's amusing that [the docs state](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#extended-usage):

> USE_CURRENT_TIMESTAMP to forgo reproducibility and use the real creation time

Yes, please, I'd like to use the real creation time.

## How to test

Ran jib:dockerBuild locally:

```
docker image inspect racker/salus-telemetry-monitor-management:0.0.1-SNAPSHOT
[
    {
        "Id": "sha256:f736078041ce3f6ba530b59519c3abd6d6034add66b323c2bbc0394f165e61b7",
        "RepoTags": [
            "racker/salus-telemetry-monitor-management:0.0.1-SNAPSHOT",
            "racker/salus-telemetry-monitor-management:latest",
            "racker/salus-telemetry-monitor-management:x"
        ],
        "RepoDigests": [],
        "Parent": "",
        "Comment": "classes",
        "Created": "2020-02-12T15:17:56.247335Z",
```