### PR TITLE
Upgraded Java runtime in app images to 11.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
                  image build; however, each is free to override any of this configuration such
                  as when an alternate base image is needed. -->
             <from>
-              <image>openjdk:11.0.3-slim</image>
+              <image>openjdk:11.0.6-slim</image>
             </from>
             <container>
               <!-- Avoid using the default, EPOCH, since that complicates pruning of images in the registry -->


### PR DESCRIPTION
# What

While looking at GCR I noticed 6 medium CVEs in the current openjdk base image.

# How

Upgraded the base image.

# TODO

I'll check GCR again after building one of the apps.