### PR TITLE
bump maven compiler plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,10 +104,9 @@
 
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
           <configuration>
-            <compilerArgs>
-              <arg>-parameters</arg>
-            </compilerArgs>
+            <parameters>true</parameters>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
Some apps were failing to build on 3.7 so I'm bumping the plugin to 3.8 for everything.

The error was something along the lines of `source option 5 is no longer supported` and my search led me to find 3.8 solved this.