### PR TITLE
Adjusted jib config to allow for one-off/dev image builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,18 +140,47 @@
               </ports>
             </container>
             <to>
-              <image>${docker.image.prefix}/${project.artifactId}</image>
-              <tags>
-                <tag>${project.version}</tag>
-                <tag>${docker.image.latest}</tag>
-                <tag>${env.SHORT_SHA}</tag>
-              </tags>
+              <!-- ensure dev builds only produce a tagged image and always prefix that tag -->
+              <image>${docker.image.prefix}/${project.artifactId}:dev-${docker.image.latest}</image>
             </to>
           </configuration>
         </plugin>
       </plugins>
     </pluginManagement>
   </build>
+
+  <profiles>
+    <profile>
+      <!--
+      For cloud builds, which are activated by SHORT_SHA env var, build with all of the tags
+      including the implicit "latest" tag.
+       -->
+      <id>cloud-build</id>
+      <activation>
+        <property><name>env.SHORT_SHA</name></property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>com.google.cloud.tools</groupId>
+              <artifactId>jib-maven-plugin</artifactId>
+              <configuration>
+                <to>
+                  <image>${docker.image.prefix}/${project.artifactId}</image>
+                  <tags>
+                    <tag>${project.version}</tag>
+                    <tag>${docker.image.latest}</tag>
+                    <tag>${env.SHORT_SHA}</tag>
+                  </tags>
+                </to>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
 
   <distributionManagement>
     <snapshotRepository>


### PR DESCRIPTION
# What

We didn't yet have a way to perform our own image builds for testing local changes in the dev/perf clusters.

# How

Changed the default jib configuration to use an always-tagged, non-latest, "dev-" prefixed image tag.

Shifted existing cloud build image tagging into a profile that is auto activated when `SHORT_SHA` env var is set. With that, the cloudbuilds of master should (hopefully) work as before.

## How to test

Manually. Let's say you want to build an ambassador image. First ensure any local changes in dependencies is locally populated into maven repo. At top level of bundle workspace run:

```
mvn -pl apps/ambassador -am install -DskipTests
```

Then in the ambassador directory run a `jib:build` specifying the one-off label to append after "dev-":

```
mvn compile jib:build -Ddocker.image.prefix=gcr.io/salus-220516 -Ddocker.image.latest=queuing-etcd-exec
```

> I'll write up a KB, but wanted to capture the basics here for now.