### PR TITLE
Upgraded fluency while resolving failsafe version conflict in jetcd

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>11</java.version>
-    <fluency.version>2.3.3</fluency.version>
+    <fluency.version>2.4.1</fluency.version>
     <spring-cloud.version>Greenwich.SR3</spring-cloud.version>
 
     <!-- Specifies the prefix of the Docker image to tag.


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-852

# What

While upgrading jetcd to 0.5.3 I encountered a maven version conflict with the `failsafe` library. I originally though upgrading fluency might help. It didn't, so I ended up resolving the conflict by pinning the version [in etcd-adapter](https://github.com/racker/salus-telemetry-etcd-adapter/pull/60/files#diff-600376dffeb79835ede4a0b285078036R75-R76), but thought I'd leave the upgrade anyway.

## How to test

I tested fluentd logging still worked by starting an app with `production` spring profile activated and launching fluentd with `dev/telemetry-infra/docker-compose-fluentd.yml`