### PR TITLE
Improved flexibility of "latest" image tag for cloud builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,10 +167,9 @@
               <artifactId>jib-maven-plugin</artifactId>
               <configuration>
                 <to>
-                  <image>${docker.image.prefix}/${project.artifactId}</image>
+                  <image>${docker.image.prefix}/${project.artifactId}:${docker.image.latest}</image>
                   <tags>
                     <tag>${project.version}</tag>
-                    <tag>${docker.image.latest}</tag>
                     <tag>${env.SHORT_SHA}</tag>
                   </tags>
                 </to>


### PR DESCRIPTION
# What

Rather than always have the most recent image build on master be tagged with `latest`, we'd like to have the option to tag those with `dev` (and the other environment/cluster identifiers) to better align with deployment automation.

We can always change the default property value here

https://github.com/racker/salus-app-base/blob/b4b20b9c9627f32a006258f061f3d8642130c415/pom.xml#L47

to be "dev", but otherwise, the cloud build trigger needs to be updated with `-Ddocker.image.latest=dev`