### PR TITLE
Included username in dev-build docker image labeling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
     <!-- Specifies the image tag to apply in addition to the tag derived from the
          application pom's project version  field -->
     <docker.image.latest>dev</docker.image.latest>
+    <docker.image.dev-qualifier>${user.name}</docker.image.dev-qualifier>
   </properties>
 
   <dependencyManagement>
@@ -141,7 +142,7 @@
             </container>
             <to>
               <!-- ensure dev builds only produce a tagged image and always prefix that tag -->
-              <image>${docker.image.prefix}/${project.artifactId}:dev-${docker.image.latest}</image>
+              <image>${docker.image.prefix}/${project.artifactId}:dev-${docker.image.dev-qualifier}</image>
             </to>
           </configuration>
         </plugin>


### PR DESCRIPTION
# What

While testing https://github.com/racker/salus-telemetry-etcd-adapter/pull/64 in the staging cluster I noticed the default `jib:build` was producing an image label with "dev-dev", which is weird looking and not helpful. 

# How

Adjusted the default label to be "dev-{username}" so that `mvn jib:build` can be run more easily with only `docker.image.prefix` property needing to be set to `gcr.io/{project-id}`.